### PR TITLE
Split Common Functionality into Shared Module

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,31 +5,25 @@ import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RecipesModule } from './recipes/recipes.module';
 import { ShoppingListModule } from './shopping-list/shopping-list.module';
 import { AppRoutingModule } from './app-routing.module';
+import { SharedModule } from './shared/shared.module';
 
 import { AuthInterceptorService } from './auth/auth-interceptor.service';
-
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/header.component';
-import { DropdownDirective } from './shared/dropdown.directive';
 import { AuthComponent } from './auth/auth.component';
-import { LoadingSpinnerComponent } from './shared/loading-spinner/loading-spinner.component';
-import { AlertComponent } from './shared/alert/alert.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    HeaderComponent,
-    DropdownDirective,
-    AuthComponent,
-    LoadingSpinnerComponent,
-    AlertComponent,
-  ],
+  declarations: [AppComponent, HeaderComponent, AuthComponent],
   imports: [
     BrowserModule,
+    FormsModule,
+    ReactiveFormsModule,
     HttpClientModule,
     AppRoutingModule,
     RecipesModule,
     ShoppingListModule,
+    SharedModule,
   ],
   providers: [
     {

--- a/src/app/recipes/recipes.module.ts
+++ b/src/app/recipes/recipes.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RecipesRoutingModule } from './recipes-routing.module';
+import { SharedModule } from '../shared/shared.module';
 
 import { RecipesComponent } from './recipes.component';
 import { RecipeListComponent } from './recipe-list/recipe-list.component';
@@ -22,7 +23,7 @@ import { RecipeEditComponent } from './recipe-edit/recipe-edit.component';
   ],
   imports: [
     RouterModule,
-    CommonModule,
+    SharedModule,
     ReactiveFormsModule,
     RecipesRoutingModule,
   ],

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { AlertComponent } from './alert/alert.component';
+import { DropdownDirective } from './dropdown.directive';
+import { LoadingSpinnerComponent } from './loading-spinner/loading-spinner.component';
+
+@NgModule({
+  declarations: [AlertComponent, LoadingSpinnerComponent, DropdownDirective],
+  imports: [CommonModule],
+  exports: [
+    AlertComponent,
+    LoadingSpinnerComponent,
+    DropdownDirective,
+    CommonModule,
+  ],
+})
+export class SharedModule {}

--- a/src/app/shopping-list/shopping-list.module.ts
+++ b/src/app/shopping-list/shopping-list.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared.module';
 
 import { ShoppingListComponent } from './shopping-list.component';
 import { ShoppingEditComponent } from './shopping-edit/shopping-edit.component';
@@ -9,7 +9,7 @@ import { ShoppingEditComponent } from './shopping-edit/shopping-edit.component';
 @NgModule({
   declarations: [ShoppingListComponent, ShoppingEditComponent],
   imports: [
-    CommonModule,
+    SharedModule,
     FormsModule,
     RouterModule.forChild([
       { path: 'shopping-list', component: ShoppingListComponent },


### PR DESCRIPTION
**Additions:** Split common functionality (e.g. alert component) into a shared module that is imported into all modules that use these shared features.

**Shared Modules Includes:**
- Alert Component
- Loading Spinner Component
- Dropdown Directive