### PR TITLE
Best practice for reducer case identifiers

### DIFF
--- a/src/app/auth/store/auth.actions.ts
+++ b/src/app/auth/store/auth.actions.ts
@@ -1,7 +1,7 @@
 import { Action } from '@ngrx/store';
 
-export const LOGIN = 'LOGIN';
-export const LOGOUT = 'LOGOUT';
+export const LOGIN = '[Auth] Login';
+export const LOGOUT = '[Auth Logout';
 
 export class Login implements Action {
   readonly type = LOGIN;

--- a/src/app/shopping-list/store/shopping-list.actions.ts
+++ b/src/app/shopping-list/store/shopping-list.actions.ts
@@ -1,12 +1,12 @@
 import { Action } from '@ngrx/store';
 import { Ingredient } from '../../shared/ingredient.model';
 
-export const ADD_INGREDIENT = 'ADD_INGREDIENT';
-export const ADD_INGREDIENTS = 'ADD_INGREDIENTS';
-export const UPDATE_INGREDIENT = 'UPDATE_INGREDIENT';
-export const DELETE_INGREDIENT = 'DELETE_INGREDIENT';
-export const START_EDIT = 'START_EDIT';
-export const STOP_EDIT = 'STOP_EDIT';
+export const ADD_INGREDIENT = '[Shopping List] Add Ingredient';
+export const ADD_INGREDIENTS = '[Shopping List] Add Ingredients';
+export const UPDATE_INGREDIENT = '[Shopping List] Update Ingredient';
+export const DELETE_INGREDIENT = '[Shopping List] Delete Ingredient';
+export const START_EDIT = '[Shopping List] Start Edit';
+export const STOP_EDIT = '[Shopping List] Stop Edit';
 
 export class AddIngredient implements Action {
   readonly type = ADD_INGREDIENT; // cannot be changed


### PR DESCRIPTION
Using NgRx best practice for reducer case identifiers. Adding a prefix to the value will help ensure we never have duplicates.